### PR TITLE
Make RSS links more consistent

### DIFF
--- a/sass/custom/_styles.scss
+++ b/sass/custom/_styles.scss
@@ -20,3 +20,6 @@ box-shadow: none;
 // box-sizing: border-box;
 border: 0;
 }
+
+// Search bar
+body>nav form { width: 250px; }

--- a/source/_includes/asides/recent_posts.html
+++ b/source/_includes/asides/recent_posts.html
@@ -2,7 +2,7 @@
     
     <!-- NOTE: Adding the custom links to the asides/recent_posts.html for now as Octopress doesn't seem to pick up my default custom/asides/home.html template set in _config.yml -->
     <a href="http://itunes.apple.com/us/podcast/the-food-fight-show/id495577922#"><img src="/images/itunes.png" alt="Subscribe with iTunes" /></a>
-    <a href="http://feeds.feedburner.com/TheFoodFightShow"><img src="/images/feed_rss.png" alt="Subscribe with RSS" /></a>    
+    <a href="/atom.xml"><img src="/images/feed_rss.png" alt="Subscribe with RSS" /></a>    
     <a href="https://twitter.com/#!/foodfightshow"><img src="/images/feed_twitter.png" alt="Subscribe with iTunes" /></a>
     <a href="http://flattr.com/thing/733271/foodfightshow-on-Flattr"><img src="/images/support-with-flattr_button.png" alt="Support with Flattr" /></a>
     <a href="http://bit.ly/ffsmail"><img src="/images/subscribe-to-newsletter_button.png" alt="Subscribe to Newsletter" /></a>

--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -1,9 +1,3 @@
-<ul class="subscription" data-subscription="rss{% if site.subscribe_email %} email{% endif %}">
-  <li><a href="{{ site.subscribe_rss }}" rel="subscribe-rss" title="subscribe via RSS">RSS</a></li>
-  {% if site.subscribe_email %}
-    <li><a href="{{ site.subscribe_email }}" rel="subscribe-email" title="subscribe via email">Email</a></li>
-  {% endif %}
-</ul>
   {% if site.simple_search %}
 <form action="{{ site.simple_search }}" method="get">
   <fieldset role="search">


### PR DESCRIPTION
There were 2 RSS links on the sidebar, one linking to
http://foodfightshow.org/atom.xml and the other to
http://feeds.feedburner.com/TheFoodFightShow. I removed the less obvious
one next to the search box and made the more obvious one link to
/atom.xml, because that's the main site and is more helpful.

Widened the search box a touch to compensate for the RSS icon that's
gone now.
