### PR TITLE
Kafka show notes: samsa -> samza

### DIFF
--- a/2014/11/apache-kafka.html
+++ b/2014/11/apache-kafka.html
@@ -186,7 +186,7 @@ Apache Kafka @ &hellip;">
 <li>Ecosystems and &#8220;The Stream&#8221;
 
 <ul>
-<li><a href="https://github.com/getsamsa/samsa">samsa</a> - Productizing Kafka</li>
+<li><a href="http://samza.incubator.apache.org/">Samza</a> - Productizing Kafka</li>
 <li>[Blog Post] Jay Kreps -<a href="http://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying"> The Log: What every software engineer should know about real-time data&#8217;s unifying abstraction</a></li>
 </ul>
 </li>


### PR DESCRIPTION
In context, it sounds like @jkreps was probably talking about their stream processing framework.

As far as I can tell, he/Confluent don't have any involvement in the python client originally linked